### PR TITLE
refactor: deixando url do asaas dinamico

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 acess_token = asaas_acess_token
+asaas_production_url = https://api.asaas.com #novo dominio 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ pip install asaas-sdk
 ```py
 from asaas import Asaas
 
-asaas = Asaas(access_token = 'acess_token', production = False)
+asaas = Asaas(access_token = 'acess_token', url_production='asaas_production_url', production = False)
 
 ``` 
 A variável `acess_token` deve receber um [token válido](https://asaasv3.docs.apiary.io/#introduction/autenticacao).
+A variável `url_production` deve receber a url de produção do Asaas.
 
 
 ### Customers

--- a/asaas/__init__.py
+++ b/asaas/__init__.py
@@ -15,12 +15,13 @@ from asaas.payments import Payment
 from asaas.exceptions import raise_for_error
 
 class Asaas():
-    def __init__(self, access_token, production = False):
+    def __init__(self, access_token, url_production, production=False):
 
         self.access_token = access_token
+        self.url_production = url_production
 
         if production:
-            self.url = 'https://www.asaas.com'
+            self.url = url_production
         else:
             self.url = 'https://sandbox.asaas.com'
 

--- a/asaas/__init__.py
+++ b/asaas/__init__.py
@@ -15,7 +15,7 @@ from asaas.payments import Payment
 from asaas.exceptions import raise_for_error
 
 class Asaas():
-    def __init__(self, access_token, url_production, production=False):
+    def __init__(self, access_token, production=False, url_production = 'https://api.asaas.com'):
 
         self.access_token = access_token
         self.url_production = url_production


### PR DESCRIPTION
No construtor da classe Asaas, adicionei um novo parametro `url_production`, que se trata da url de produção do asaas. Fiz isso visando situações onde o Asaas possa alterar novamente o seu domínio e possamos setar dinamicamente em nosso projeto, que foi o que aconteceu e motivou a fazer esse pr.  O sandbox não mudou, então não foi necessário alterá-lo.